### PR TITLE
Add xkb rules to allow engram to appear as an option in DE's keyboard input lists (Linux)

### DIFF
--- a/keymaps/linux/Makefile
+++ b/keymaps/linux/Makefile
@@ -1,15 +1,19 @@
-TARGET := /usr/share/X11/xkb/symbols/us
-SOURCE := usr-share-X11-xkb-symbols-us
+TARGET_SYM := /usr/share/X11/xkb/symbols/us
+SOURCE_SYM := usr-share-X11-xkb-symbols-us
+TARGET_RULE := /usr/share/X11/xkb/rules/evdev.xml
+SOURCE_RULE := usr-share-X11-xkb-rules-evdev
 
 all: reinstall
 
-install: $(SOURCE) $(TARGET)
-	echo '//ENGRAM//BEGIN' >> $(TARGET)
-	cat $(SOURCE) >> $(TARGET)
-	echo '//ENGRAM//END' >> $(TARGET)
+install: $(SOURCE_SYM) $(TARGET_SYM) $(SOURCE_RULE) $(TARGET_RULE)
+	echo '//ENGRAM//BEGIN' >> $(TARGET_SYM)
+	cat $(SOURCE_SYM) >> $(TARGET_SYM)
+	echo '//ENGRAM//END' >> $(TARGET_SYM)
+	sed -i "$$(awk '/variantList/ {print NR; exit}' $(TARGET_RULE)) r $(SOURCE_RULE)" $(TARGET_RULE)
 
-uninstall: $(TARGET)
-	sed -i '/^\/\/ENGRAM\/\/BEGIN$$/,/^\/\/ENGRAM\/\/END$$/d' $<
+uninstall: $(TARGET_SYM) $(TARGET_RULE)
+	sed -i '/^\/\/ENGRAM\/\/BEGIN$$/,/^\/\/ENGRAM\/\/END$$/d' $(TARGET_SYM)
+	sed -i '/ENGRAM BEGIN/,/ENGRAM END/d' $(TARGET_RULE)
 
 reinstall:
 	$(MAKE) uninstall

--- a/keymaps/linux/README.md
+++ b/keymaps/linux/README.md
@@ -4,6 +4,8 @@ Install:
 
     sudo make install
     echo Now restart your X session.
+    
+The Engram layout should be available under your desktop environment's keyboard selection utility.
 
 Activate:
 

--- a/keymaps/linux/usr-share-X11-xkb-rules-evdev
+++ b/keymaps/linux/usr-share-X11-xkb-rules-evdev
@@ -1,0 +1,8 @@
+<!-- ENGRAM BEGIN -->
+        <variant>
+          <configItem>
+            <name>engram</name>
+            <description>English (Engram)</description>
+          </configItem>
+        </variant>
+<!-- ENGRAM END -->


### PR DESCRIPTION
As discussed in #38.
I have since been able to corroborate this solution is applicable to other desktops.
## KDE Plasma
![plasma](https://user-images.githubusercontent.com/97045533/148605711-93032b2d-9843-43ba-950d-a6df1cc5ad3a.png)
## XFCE
![xfce](https://user-images.githubusercontent.com/97045533/148605718-b15100af-39f3-4eb7-88d8-86cb29d54e25.png)