### PR TITLE
Add KMonad Examples to Mac Install

### DIFF
--- a/install/mac/karabiner/README.md
+++ b/install/mac/karabiner/README.md
@@ -12,7 +12,7 @@ Engram layouts for Karabiner.
 ```           
 
 
-# Using Karabiner with Engram
+## Using Karabiner with Engram
 
 To use the vanilla Engram layout on MacOS, simply
 
@@ -26,26 +26,10 @@ Or you can view the JSON [here](https://raw.githubusercontent.com/binarybottle/e
 
 This directory also includes [Karabiner.ts](https://github.com/evan-liu/karabiner.ts) config, as well as a [Goku](https://github.com/yqrashawn/GokuRakuJoudo) config.
 
-Home Row Mods are working better in the Karabiner.ts config than the Goku one. (They're configured as simlayers in the Karabiner.ts version.) Karabiner.ts also 🏃🏻‍♂️s 53 times faster--73.6ms vs. 3.947s. 
 
-The command keys are set to work more like they do on a mech ergo board.
+## Home Row Mods
 
-Currently, Home Row Mods work only one at a time, but hoping to get that sorted shortly. 🤓
-
-Karabiner still has some shortcomings. It seems like no matter how it's configured, typing rhythm isn't as natural with Karabiner as it is with [timeless Home Row Mods](https://github.com/urob/zmk-config#timeless-homerow-mods) in zmk using below config. 
-
-```dtsi
-    hrml: home_row_mod_left {
-        compatible = "zmk,behavior-hold-tap";
-        label = "HOME_ROW_MOD_LEFT";
-        #binding-cells = <2>;
-        flavor = "balanced";
-        tapping-term-ms = <HM_TAPPING_TERM>;
-        hold-trigger-key-positions = < KEYS_R THUMBS >;
-        hold-trigger-on-release;
-        bindings = <&kp>, <&kp>;
-        };
-```        
+Home row mods don't work very well in Karabiner. If you are interested in using home row mods on MacOS, you'll probably be happier installing KMonad, also documented in the `engram/install/mac` directory.
 
 
 ## Installing

--- a/install/mac/kmonad/README.md
+++ b/install/mac/kmonad/README.md
@@ -1,0 +1,18 @@
+# KMonad and Engram
+
+[KMonad](https://github.com/kmonad/kmonad), **the onion of keyboard management**, is a cross platform keyboard management tool. It's `.kbd` config files are concise and easy to read and alter. 
+
+The example configs in this directory are laid out for a MacBook/Air/Pro keyboard, but could easily be adapted or used as a starting point to configure Engram on Linx or Windows as well. KMonad makes trivial work of home row mods. It is fast and easy to work with and may become your preferred way of changing layouts.
+
+Follow [this gist](https://gist.github.com/amiorin/4c74f63fe599a1dcbd0933628df1aac9) by @amiorin to build KMonad. You can replace the `stack build` command with `stack install` and it should place the compiled binaries appropriately on your system. If you don't happen to have haskell installed on your system already, try running `brew install haskell-stack` before proceeding with the above insturctions.
+
+To have the layout load on startup, install the `kmonad.plist` file found in this directory, either via launchctl or, should you prefer to use the GUI, with something like [LaunchControl](https://www.soma-zone.com/LaunchControl/).
+
+Switching to home row mods leaves quite a few spare keys on your keyboard. You can remap these to frequently typed phrases with KMonad's __tap macro__ system:
+
+```kmonad
+    (tap-macro K M o n a d)
+    #(K M o n a d)
+```
+
+There are a few examples included in the sample configuration files in this directory. `engram.kbd` is the vanilla variant that adheres strictly to the official engram layout. `engram-hrm.kbd` also adheres to the vanilla layout, but includes home row mods. An `engrammer.kbd` example is included as well, both for breadth, and to demonstrate KMonad's macro system in practice. See the [KMonad Configuration Guide](https://github.com/kmonad/kmonad/blob/1b2ec006259ddbe6cda30db8eb783e8177a9f12b/keymap/tutorial.kbd#L481C1-L481C2) for more detailed instructions.

--- a/install/mac/kmonad/engram-hrm.kbd
+++ b/install/mac/kmonad/engram-hrm.kbd
@@ -1,0 +1,60 @@
+;; See kmonad's keymap/tutorial.kbd for a more complete tutorial
+
+;; Engram, for reference
+;;  [{ 1| 2= 3~ 4+  5<  6>  7^ 8& 9% 0* ]} /\
+;;     bB yY oO uU  '(  ")  lL dD wW vV zZ #$ @`
+;;     cC iI eE aA  ,;  .:  hH tT sS nN qQ 
+;;     gG xX jJ kK  -_  ?!  rR mM fF pP
+
+(defcfg
+  input (iokit-name "Apple Internal Keyboard / Trackpad")
+  output (kext)
+  fallthrough true
+  allow-cmd false
+  )
+
+(defsrc
+  grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc
+  tab  q    w    e    r    t    y    u    i    o    p    [    ]    \
+  caps a    s    d    f    g    h    j    k    l    ;    '    ret
+  lsft z    x    c    v    b    n    m    ,    .    /    rsft up
+  fn   lctl lalt lmet           spc            rmet ralt left down rght
+)
+
+(defalias
+    up (layer-toggle engram_shifted_homerow_mods)
+
+    cc (tap-hold-next-release 200 c lctl)
+    ai (tap-hold-next-release 200 i lalt)
+    me (tap-hold-next-release 200 e lmet)
+    sa (tap-hold-next-release 200 a @up)
+    sh (tap-hold-next-release 200 h @up)
+    mt (tap-hold-next-release 200 t rmet)
+    as (tap-hold-next-release 200 s lalt)
+    cn (tap-hold-next-release 200 n rctl)
+    
+    csc (tap-hold-next-release 200 C S-lctl)
+    asi (tap-hold-next-release 200 I S-lalt)
+    mse (tap-hold-next-release 200 E S-lmet)
+    ssa (tap-hold-next-release 200 A lsft)
+    ssh (tap-hold-next-release 200 H rsft)
+    mst (tap-hold-next-release 200 T S-rmet)
+    ass (tap-hold-next-release 200 S S-lalt)
+    csn (tap-hold-next-release 200 N S-rctl)
+)
+
+(deflayer engram_homerow_mods
+  [    1    2    3    4    5    6    7    8    9    0    ]    /    bspc
+  tab  b    y    o    u    '    "    l    d    w    v    z    #    @
+  caps @cc  @ai  @me  @sa  ,    .    @sh  @mt  @as  @cn  q    ret
+  @up  g    x    j    k    -    ?    r    m    f    p    @up  up
+  fn   lctl lalt lmet           spc            rmet ralt left down rght
+)
+
+(deflayer engram_shifted_homerow_mods
+ {    |    =    ~    +    <    >    ^    &    %    *    }    \    S-bspc
+ tab  B    Y    O    U    \(   \)   L    D    W    V    Z    $    `
+ caps @csc @asi @mse @ssa ;    :    @ssh @mst @ass @csn Q    S-ret
+ @up  G    X    J    K    _    !    R    M    F    P    @up  S-up
+ S-fn S-lctl S-lalt S-lmet     S-spc          S-rmet S-ralt S-left S-down S-rght
+)

--- a/install/mac/kmonad/engram.kbd
+++ b/install/mac/kmonad/engram.kbd
@@ -1,0 +1,42 @@
+;; See kmonad's keymap/tutorial.kbd for a more complete tutorial
+
+;; Engram, for reference
+;;  [{ 1| 2= 3~ 4+  5<  6>  7^ 8& 9% 0* ]} /\
+;;     bB yY oO uU  '(  ")  lL dD wW vV zZ #$ @`
+;;     cC iI eE aA  ,;  .:  hH tT sS nN qQ 
+;;     gG xX jJ kK  -_  ?!  rR mM fF pP
+
+(defcfg
+  input (iokit-name "Apple Internal Keyboard / Trackpad")
+  output (kext)
+  fallthrough true
+  allow-cmd false
+  )
+
+(defsrc
+  grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc
+  tab  q    w    e    r    t    y    u    i    o    p    [    ]    \
+  caps a    s    d    f    g    h    j    k    l    ;    '    ret
+  lsft z    x    c    v    b    n    m    ,    .    /    rsft up
+  fn   lctl lalt lmet           spc            rmet ralt left down rght
+)
+
+(defalias
+    up (layer-toggle engram_shifted)
+)
+
+(deflayer engram
+  [    1    2    3    4    5    6    7    8    9    0    ]    /    bspc
+  tab  b    y    o    u    '    "    l    d    w    v    z    #    @
+  caps c    i    e    a    ,    .    h    t    s    n    q    ret
+  @up  g    x    j    k    -    ?    r    m    f    p    @up  up
+  fn   lctl lalt lmet           spc            rmet ralt left down rght
+)
+
+(deflayer engram_shifted
+ {    |    =    ~    +    <    >    ^    &    %    *    }    \    S-bspc
+ tab  B    Y    O    U    \(   \)   L    D    W    V    Z    $    `
+ caps C    I    E    A    ;    :    H    T    S    N    Q    S-ret
+ @up  G    X    J    K    _    !    R    M    F    P    @up  S-up
+ S-fn S-lctl S-lalt S-lmet     S-spc          S-rmet S-ralt S-left S-down S-rght
+)

--- a/install/mac/kmonad/engrammer.kbd
+++ b/install/mac/kmonad/engrammer.kbd
@@ -1,0 +1,56 @@
+;; See keymap/tutorial.kbd for a more complete tutorial
+
+(defcfg
+  input (iokit-name "Apple Internal Keyboard / Trackpad")
+  output (kext)
+  fallthrough true
+  allow-cmd false
+  )
+
+(defsrc
+  grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc
+  tab  q    w    e    r    t    y    u    i    o    p    [    ]    \
+  caps a    s    d    f    g    h    j    k    l    ;    '    ret
+  lsft z    x    c    v    b    n    m    ,    .    /    rsft up
+  fn   lctl lalt lmet           spc            rmet ralt left down rght
+)
+
+(defalias
+    cc (tap-hold-next-release 200 c lctl)
+    ai (tap-hold-next-release 200 i lalt)
+    me (tap-hold-next-release 200 e lmet)
+    sa (tap-hold-next-release 200 a lsft)
+    sh (tap-hold-next-release 200 h rsft)
+    mt (tap-hold-next-release 200 t rmet)
+    as (tap-hold-next-release 200 s lalt)
+    cn (tap-hold-next-release 200 n rctl)
+    nav (tap-hold 180 caps (layer-toggle navigation))
+    af #(spc \( \) spc = > spc )
+    ht #(h t t p s : / /)
+    moi #(Y o u r spc N a m e)
+
+)
+
+(deflayer engram_homerow_mods
+  grv  1    2    3    4    5    6    7    8    9    0    [    ]    bspc
+  tab  b    y    o    u    '    ;    l    d    w    v    z    =    \
+  @nav @cc  @ai  @me  @sa  ,    .    @sh  @mt  @as  @cn  q    ret
+  g    x    j    k    -    @af  /    r    m    f    p    @ht  up
+  fn   M-spc esc bspc           spc            ret  @moi left down rght
+)
+
+(deflayer navigation
+  _    _    _    _    _    _    _    _    _    _    _    _    _    _
+  _    _    _    _    _    _    _    home pgdn pgup end  _    _    _
+  _    _    _    _    _    _    _    left down up   rght _    _
+  _    _    _    _    _    _    M-S-z M-z M-x  M-c  M-v  _    _
+  _    _    _    _              _              _    _    _    _    _
+)
+
+;; (deflayer blank
+;;   _    _    _    _    _    _    _    _    _    _    _    _    _    _
+;;   _    _    _    _    _    _    _    _    _    _    _    _    _    _
+;;   _    _    _    _    _    _    _    _    _    _    _    _    _
+;;   _    _    _    _    _    _    _    _    _    _    _    _    _
+;;   _    _    _    _              _              _    _    _    _    _
+;; )

--- a/install/mac/kmonad/kmonad.plist
+++ b/install/mac/kmonad/kmonad.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>kmonad</string>
+	<key>Program</key>
+	<string>/bin/sh</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>kmonad</string>
+		<string>-c</string>
+		<string>/usr/bin/sudo ~/.local/bin/kmonad ~/.local/config/engrammer.kbd</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/tmp/kmonad.stderr</string>
+	<key>StandardOutPath</key>
+	<string>/tmp/kmonad.stdout</string>
+</dict>
+</plist>


### PR DESCRIPTION
KMonad simplifies creating more complex configurations, and is more responsive on MacOS. It also makes trivial work of home row mods.