### PR TITLE
Fix/Optimize Linux Install Script

### DIFF
--- a/install/linux/x_keyboard_extension/Makefile
+++ b/install/linux/x_keyboard_extension/Makefile
@@ -1,18 +1,17 @@
-TARGET_SYM := /usr/share/X11/xkb/symbols/us
+XKB_BASE := /usr/share/X11/xkb
+TARGET_SYM := $(XKB_BASE)/symbols/us
+TARGET_RULE := $(XKB_BASE)/rules/evdev.xml
 SOURCE_SYM := usr-share-X11-xkb-symbols-us
-TARGET_RULE := /usr/share/X11/xkb/rules/evdev.xml
 SOURCE_RULE := usr-share-X11-xkb-rules-evdev
 
 all: reinstall
 
 install: $(SOURCE_SYM) $(TARGET_SYM) $(SOURCE_RULE) $(TARGET_RULE)
-	echo '//ENGRAM//BEGIN' >> $(TARGET_SYM)
 	cat $(SOURCE_SYM) >> $(TARGET_SYM)
-	echo '//ENGRAM//END' >> $(TARGET_SYM)
-	sed -i "$$(awk '/variantList/ {print NR; exit}' $(TARGET_RULE)) r $(SOURCE_RULE)" $(TARGET_RULE)
+	sed -i '/English (US)/,/<variantList>/!b ; /<variantList>/r $(SOURCE_RULE)' $(TARGET_RULE)
 
 uninstall: $(TARGET_SYM) $(TARGET_RULE)
-	sed -i '/^\/\/ENGRAM\/\/BEGIN$$/,/^\/\/ENGRAM\/\/END$$/d' $(TARGET_SYM)
+	sed -i '/^\/\/ENGRAM BEGIN$$/,/^\/\/ENGRAM END$$/d' $(TARGET_SYM)
 	sed -i '/ENGRAM BEGIN/,/ENGRAM END/d' $(TARGET_RULE)
 
 reinstall:

--- a/install/linux/x_keyboard_extension/usr-share-X11-xkb-symbols-us
+++ b/install/linux/x_keyboard_extension/usr-share-X11-xkb-symbols-us
@@ -1,8 +1,9 @@
+//ENGRAM BEGIN
 // Arno's Engram keyboard layout v2.0 - https://engram.dev
-partial alphanumeric_keys
+partial alphanumeric_keys modifier_keys
 xkb_symbols "engram"
 {
-	include "us(basic)"
+	name[Group1]="English (Engram)";
 
 	key <TLDE> { [  bracketleft,   braceleft ] }; // [{
 	key <AE01> { [            1,         bar ] }; // 1|
@@ -55,3 +56,4 @@ xkb_symbols "engram"
 	key <AB09> { [            f,           F ] }; // fF
 	key <AB10> { [            p,           P ] }; // pP
 };
+//ENGRAM END


### PR DESCRIPTION
The X Keyboard Configuration Database updated its rules file `evdev.xml`. As a result, the installation script now enters the engram rules under the wrong layout. This fix uses a more robust logic to patch the engram entries as a valid variant of the `us` layout only.